### PR TITLE
chore: update versioning workflow

### DIFF
--- a/.github/workflows/version_bump.yaml
+++ b/.github/workflows/version_bump.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.03
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
           node-version: '20'
 
       - name: Create Release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
           release-type: node


### PR DESCRIPTION
Update deprecated workflow parameters

## Summary by Sourcery

Update the release workflow to use the latest Ubuntu version and release-please action.

CI:
- Update the Ubuntu runner from `ubuntu-latest` to `ubuntu-24.03`.
- Update `google-github-actions/release-please-action` from v4 to v3.