### PR TITLE
chore: fix runnner image

### DIFF
--- a/.github/workflows/version_bump.yaml
+++ b/.github/workflows/version_bump.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-24.03
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use `ubuntu-latest` as the runner image.